### PR TITLE
Read, display and output descriptions.

### DIFF
--- a/man/man1/pick.1
+++ b/man/man1/pick.1
@@ -9,6 +9,7 @@
 .Op Fl h
 .Op Fl v
 .Op Fl q Ar QUERY
+.Op Fl d Op Fl o
 .Sh DESCRIPTION
 .Nm pick
 allows users to select from a set of choices using an
@@ -22,11 +23,23 @@ accepts a list of choices as input and produces the selected choice as output.
 supports these options and arguments:
 .Bl -tag -width "\&-q QUERY"
 .It Fl h
-display a help message and exit.
+output a help message and exit.
 .It Fl v
-display the version and exit.
+output the version and exit.
 .It Fl q Ar QUERY
 supply an initial search query.
+.It Fl d
+read and display descriptions.
+.Pp
+When the
+.Fl d
+option is supplied, input lines will be split into two parts by the last
+occurence of
+.Ev IFS .
+Both parts will be displayed but only the first part will be used when
+searching.
+.It Fl o
+output description of selected on exit.
 .El
 .Pp
 The
@@ -59,6 +72,12 @@ Delete to the beginning of the line in the search query input field.
 .It Ic "Ctrl\&-K"
 Delete to the end of the line in the search query input field.
 .El
+.Sh ENVIRONMENT
+The following environment variables will affect the execution of
+.Nm pick :
+.Bl -tag -width IFS
+.It Ev IFS
+Determines the separator used between choices and descriptions.
 .Sh EXAMPLES
 .Nm pick
 can be used to select anything and is very effective when combined with
@@ -69,6 +88,12 @@ Select a file in the current directory to open using
 .Xr xdg-open 1 :
 .Bd -literal -offset indent
 find -type f | pick | xargs xdg-open
+.Ed
+.Pp
+Select a man page to display with
+.Xr man 1 :
+.Bd -literal -offset indent
+apropos -l . | fltr | pick -do | tac | xargs man
 .Ed
 .Sh AUTHORS
 .An "Calle Erlandsson" Aq calle@thoughtbot.com

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_LDFLAGS=-lncurses
+AM_LDFLAGS=-lncurses -lbsd
 AM_CFLAGS=-Wall -Wextra -pedantic-errors -Wno-unused-parameter -Werror
 bin_PROGRAMS=pick
 dist_pick_SOURCES=choice.c choice.h choices.c choices.h io.c io.h main.c ui.c ui.h compat/queue.h

--- a/src/choice.c
+++ b/src/choice.c
@@ -7,13 +7,14 @@
 #include "choice.h"
 
 struct choice *
-choice_new(char *str, float score)
+choice_new(char *str, char *desc, float score)
 {
 	struct choice *c;
 	
 	if ((c = malloc(sizeof(struct choice))) == NULL)
 		err(1, "malloc");
 	c->str = strdup(str);
+	c->desc = strdup(desc);
 	c->score = score;
 	return c;
 }
@@ -22,5 +23,6 @@ void
 choice_free(struct choice *c)
 {
 	free(c->str);
+	free(c->desc);
 	free(c);
 }

--- a/src/choice.h
+++ b/src/choice.h
@@ -9,11 +9,12 @@
 
 struct choice {
     char *str;
+    char *desc;
     float score;
     SLIST_ENTRY(choice) choices;          /* List. */
 };
 
-struct choice   *choice_new(char *, float);
+struct choice   *choice_new(char *, char *, float);
 void             choice_free(struct choice *);
 
 #endif /* CHOICHE_H */

--- a/src/io.c
+++ b/src/io.c
@@ -1,6 +1,7 @@
 #include <err.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef HAVE_FULL_QUEUE_H
 #include <sys/queue.h>
@@ -20,13 +21,18 @@ chomp(char *str, ssize_t len)
 }
 
 struct choices *
-get_choices()
+get_choices(int parse_desc)
 {
 	struct choices *cs;
 	struct choice *c;
 	char *line;
+	char *desc;
+	char *ifs;
 	size_t n;
 	ssize_t len;
+
+	if ((ifs = getenv("IFS")) == NULL)
+		ifs = " ";
 
 	if ((cs = malloc(sizeof(struct choices))) == NULL)
 		err(1, "malloc");
@@ -35,11 +41,14 @@ get_choices()
 
 	for (;;) {
 		line = NULL;
+		desc = "";
 		n = 0;
 		if ((len = getline(&line, &n, stdin)) == -1)
 			break;
 		chomp(line, len);
-		c = choice_new(line, 1);
+		if (parse_desc)
+			strtok_r(line, ifs, &desc);
+		c = choice_new(line, desc, 1);
 		SLIST_INSERT_HEAD(cs, c, choices);
 		free(line);
 	}
@@ -49,7 +58,9 @@ get_choices()
 }
 
 void
-put_choice(struct choice *c)
+put_choice(struct choice *c, int output_desc)
 {
 	printf("%s\n", c->str);
+	if (output_desc)
+		printf("%s\n", c->desc);
 }

--- a/src/io.h
+++ b/src/io.h
@@ -4,7 +4,7 @@
 #include "choices.h"
 #include "choice.h"
 
-struct choices  *get_choices();
-void             put_choice(struct choice *);
+struct choices  *get_choices(int);
+void             put_choice(struct choice *, int);
 
 #endif /* IO_H */

--- a/src/main.c
+++ b/src/main.c
@@ -15,14 +15,24 @@ int
 main(int argc,char **argv)
 {
 	int ch;
+	int display_desc;
+	int output_desc;
 	char *query;
 	struct choices *cs;
 
+	display_desc = 0;
+	output_desc = 0;
 	query = "";
-	while ((ch = getopt(argc, argv, "hvq:")) != -1)
+	while ((ch = getopt(argc, argv, "hvdoq:")) != -1)
 		switch (ch) {
 		case 'v':
 			version();
+		case 'd':
+			display_desc = 1;
+			break;
+		case 'o':
+			output_desc = 1;
+			break;
 		case 'q':
 			query = optarg;
 			break;
@@ -32,8 +42,10 @@ main(int argc,char **argv)
 	argc -= optind;
 	argv += optind;
 
-	cs = get_choices();
-	put_choice(get_selected(cs, query));
+	output_desc = output_desc && display_desc;
+
+	cs = get_choices(display_desc);
+	put_choice(get_selected(cs, query), output_desc);
 	choices_free(cs);
 	return EX_OK;
 }
@@ -41,10 +53,12 @@ main(int argc,char **argv)
 void
 usage()
 {
-	fprintf(stderr, "usage: pick [-h] [-v] [-q QUERY]\n");
-	fprintf(stderr, "    -h          display this help message and exit\n");
-	fprintf(stderr, "    -v          display the version and exit\n");
+	fprintf(stderr, "usage: pick [-h] [-v] [-q QUERY] [-d [-o]] \n");
+	fprintf(stderr, "    -h          output this help message and exit\n");
+	fprintf(stderr, "    -v          output the version and exit\n");
 	fprintf(stderr, "    -q QUERY    supply an initial search query\n");
+	fprintf(stderr, "    -d          read and display descriptions\n");
+	fprintf(stderr, "    -o          output description of selected on exit\n");
 	exit(EX_USAGE);
 }
 


### PR DESCRIPTION
Add support for splitting input lines by `IFS` and using the last part as a
description. The description is not searchable and serves the purpose of
providing context to choices without affecting the search.

Searching the following input with the search string `"Time"` without
support for descriptions would discriminate the `Time` choice since it is
longer than `time 1` and `time 2`. With description support they will all be
treated the same.

```
time 1
time 2
Time 3-ruby-2-1-0
```
