### PR TITLE
Explicitly catch CTRL-C

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -32,13 +32,19 @@
 #define KEY_DEL 127
 #define KEY_REAL_ENTER 10 /* curses.h defines KEY_ENTER to be Ctrl-Enter */
 
+#define EX_SIG 128
+#define EX_SIGINT (EX_SIG + SIGINT)
+
 int stdoutfd;
+
+void int_handler();
 
 void
 start_curses()
 {
 	int fd;
 
+	signal(SIGINT, int_handler);
 	freopen("/dev/tty", "r", stdin);
 	setlocale(LC_ALL, "");
 	fflush(stdout);
@@ -61,6 +67,13 @@ stop_curses()
 	fflush(stdout);
 	dup2(stdoutfd, STDOUT_FILENO);
 	close(stdoutfd);
+}
+
+void
+int_handler()
+{
+	stop_curses();
+	exit(EX_SIGINT);
 }
 
 void


### PR DESCRIPTION
This fixes an issue where, when the user pressed CTRL-C, the screen
wouldn't be redrawn because we didn't have time to clean up.

Fixes the new issues in https://github.com/thoughtbot/pick/issues/4

This also requires a new snippet of Vimscript:

``` vim
let selection = system(a:choice_command . " | pick")
redraw!
if strlen(selection) > 0
  exec a:vim_command . " " . alternate#EscapeFilePath(selection)
endif
```

Instead of catching an interrupt here, we just make sure we get back
some non-zero length string.

I'd be happy for better suggestions about how to handle this. Really we
just need to clean up before exiting, which didn't happen before when
the user pressed CTRL-C
