### PR TITLE
Don't refresh the screen on close.

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -63,7 +63,6 @@ void
 stop_curses()
 {
 	endwin();
-	refresh();
 	fflush(stdout);
 	dup2(stdoutfd, STDOUT_FILENO);
 	close(stdoutfd);


### PR DESCRIPTION
This reverts commit `dcc7a8bb52be649cc55a37c9e2b7dee3ab63d2f0`.

`dcc7a8bb` fixed issues when exiting out of Vim but broke using `pick(1)`
from the command line. Since `pick(1)` is a multi purpose tool, not Vim
specific, and since it was usable in Vim without the changes `dcc7a8bb` it
is reverted.
