### PR TITLE
Make curl follow redirect to package location

### DIFF
--- a/INSTALL.md.in
+++ b/INSTALL.md.in
@@ -3,7 +3,7 @@ pick installation
 
 1. Download and extract the latest release:
 
-        curl -O https://github.com/mptre/pick/releases/download/v@PACKAGE_VERSION@/pick-@PACKAGE_VERSION@.tar.gz
+        curl -L -O https://github.com/mptre/pick/releases/download/v@PACKAGE_VERSION@/pick-@PACKAGE_VERSION@.tar.gz
         tar -zxvf pick-@PACKAGE_VERSION@.tar.gz
         cd pick-@PACKAGE_VERSION@
 


### PR DESCRIPTION
Using the command within INSTALL.md verbatim yields:

```
$ curl -O https://github.com/mptre/pick/releases/download/v2.0.2/pick-2.0.2.tar.gz
$ cat pick-2.0.2.tar.gz
<html><body>You are being <a href="https://github-production-release-asset-2e65be.s3.amazonaws.com/23039777/....">redirected</a>.</body></html>
```

In order to successfully retrieve the file, curl needs to follow this redirect.