### PR TITLE
Fix build on illumos/Solaris

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -9,7 +9,7 @@
 #define __dead __dead2
 #endif /* __FreeBSD__ */
 
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__sun__) || defined(__CYGWIN__)
 #ifndef __dead
 #ifdef __GNUC__
 #define __dead		__attribute__((__noreturn__))
@@ -17,7 +17,7 @@
 #define __dead
 #endif
 #endif
-#endif /* __linux__ || __CYGWIN__ */
+#endif /* __linux__ || __sun__ || __CYGWIN__ */
 
 #ifndef HAVE_REALLOCARRAY
 

--- a/tests/pick-test.c
+++ b/tests/pick-test.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <termios.h>
 #include <unistd.h>
 
 #include "compat.h"


### PR DESCRIPTION
... there are still some warnings because of their system curses ... but it compiles and works!

`termios.h` is needed in `pick-test.c` for `TIOCSWINSZ`, but the call fails with `EINVAL`, which
seems to be a known bug: by ignoring the error most tests passed (only `key-alt-enter.t`
and `key-enter.t` timed out) ...

`/bin/sh` is `ksh93` there: no `local`-keyword, `diff` does not support the `-L` option ...
