### PR TITLE
Add support for building on Haiku/BeOS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS=foreign
 
-AM_CFLAGS=-Wall -Wextra
-AM_CPPFLAGS=-D_GNU_SOURCE
+AM_CFLAGS=-Wall
+AM_CPPFLAGS=-D_GNU_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE
 
 bin_PROGRAMS=pick
 pick_SOURCES=pick.c compat-reallocarray.c compat-strtonum.c compat.h

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_CHECK_FUNCS([pledge reallocarray strtonum])
+AC_SEARCH_LIBS([err], [bsd])
 AC_SEARCH_LIBS([setupterm], [curses], [], [
   AC_SEARCH_LIBS([setupterm], [ncursesw],
     [AC_DEFINE([HAVE_NCURSESW_H], [1], [Define if ncursesw is available])],

--- a/pick.c
+++ b/pick.c
@@ -674,7 +674,9 @@ tty_init(int doinit)
 	new_attributes.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
 	new_attributes.c_cc[VMIN] = 1;
 	new_attributes.c_cc[VTIME] = 0;
+#ifdef VDISCARD
 	new_attributes.c_cc[VDISCARD] = _POSIX_VDISABLE;
+#endif
 	tcsetattr(fileno(tty_in), TCSANOW, &new_attributes);
 
 	if (doinit && (tty_out = fopen("/dev/tty", "w")) == NULL)


### PR DESCRIPTION
`gcc 2.95` on Haiku/BeOS does not support `-Wextra`, `_BSD_SOURCE` is needed for `err`
and `_DEFAULT_SOURCE` to silence the compiler, that the previous macro is deprecated ...

`VDISCARD` is not in `POSIX.1` and (therefore?) not supported on Haiku/BeOS ...

`make check` does not work: `TIOCNOTTY` is "missing" ... no matter,  `test-suite.log` file
shows lots of  `pick-test: /dev/tt/p1: Operation not allowed` ...

Anyway, `pick` is running fine ...