### PR TITLE
makefile: Comply with GNU standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ DISTFILES+=	tests/opt-x.t
 DISTFILES+=	tests/pick-test.c
 DISTFILES+=	tests/pick-test.sh
 
-PREFIX=	/usr/local
+PREFIX?=	/usr/local
 
 all: ${PROG}
 

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ DISTFILES+=	tests/pick-test.c
 DISTFILES+=	tests/pick-test.sh
 
 PREFIX?=	/usr/local
+MANDIR?=	${PREFIX}/share/man
 
 all: ${PROG}
 
@@ -100,8 +101,8 @@ distclean: clean
 install: ${PROG}
 	@mkdir -p ${DESTDIR}${PREFIX}/bin
 	${INSTALL} ${PROG} ${DESTDIR}${PREFIX}/bin
-	@mkdir -p ${DESTDIR}${PREFIX}/man/man1
-	${INSTALL} ${.CURDIR}/pick.1 ${DESTDIR}${PREFIX}/man/man1
+	@mkdir -p ${DESTDIR}${MANDIR}/man1
+	${INSTALL} ${.CURDIR}/pick.1 ${DESTDIR}${MANDIR}/man1
 .PHONY: install
 
 test: ${PROG}


### PR DESCRIPTION
This PR:

- Makes `$PREFIX` configurable
- Introduces the `$MANDIR` variable 

Since autotools was dropped, I propose these changes to comply with [GNU standards](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables) which are widely used by package maintainer scripts (at least in Debian).