### PR TITLE
Honor BINDIR during configure and install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ distclean: clean
 .PHONY: distclean
 
 install: ${PROG}
-	@mkdir -p ${DESTDIR}${PREFIX}/bin
-	${INSTALL} ${PROG} ${DESTDIR}${PREFIX}/bin
+	@mkdir -p ${DESTDIR}${BINDIR}
+	${INSTALL} ${PROG} ${DESTDIR}${BINDIR}
 	@mkdir -p ${DESTDIR}${MANDIR}/man1
 	${INSTALL_MAN} ${.CURDIR}/pick.1 ${DESTDIR}${MANDIR}/man1
 .PHONY: install

--- a/configure
+++ b/configure
@@ -142,6 +142,7 @@ INSTALL_MAN=$(makevar INSTALL_MAN)
 : "${LDFLAGS:=}"
 
 : "${PREFIX:=/usr/local}"
+: "${BINDIR:=${PREFIX}/bin}"
 : "${MANDIR:=${PREFIX}/man}"
 : "${INSTALL:=install}"
 : "${INSTALL_MAN:=install -m 444}"
@@ -229,7 +230,7 @@ DEBUG=		$(echo $DEBUG)
 LDFLAGS=	$(echo $LDFLAGS)
 MALLOC_OPTIONS=	$(echo $MALLOC_OPTIONS)
 
-PREFIX?=	$(echo $PREFIX)
+BINDIR?=	$(echo $BINDIR)
 MANDIR?=	$(echo $MANDIR)
 INSTALL?=	$(echo $INSTALL)
 INSTALL_MAN?=	$(echo $INSTALL_MAN)


### PR DESCRIPTION
Ran into some problems while trying to package for OpenBSD. Turns out it's a better idea to only honor `PREFIX` during configure and during install always use dedicated variables for paths.

Does this work for everyone else?

/cc @dbotw @eavgerinos 