### PR TITLE
Fix compile error on GCC 10 (Fedora 32)

### DIFF
--- a/compat-pledge.c
+++ b/compat-pledge.c
@@ -1,6 +1,6 @@
 #include "config.h"
 
-int unused;
+extern int unused;
 
 #ifndef HAVE_PLEDGE
 

--- a/compat-reallocarray.c
+++ b/compat-reallocarray.c
@@ -1,6 +1,6 @@
 #include "config.h"
 
-int unused;
+extern int unused;
 
 #ifndef HAVE_REALLOCARRAY
 

--- a/compat-strtonum.c
+++ b/compat-strtonum.c
@@ -1,6 +1,6 @@
 #include "config.h"
 
-int unused;
+extern int unused;
 
 #ifndef HAVE_STRTONUM
 


### PR DESCRIPTION
GCC 10 complains about the unused variable called "unused"

Adding `extern` to the declarations fixes the error.

Fixes #301