### PR TITLE
add missing enter key mapping

### DIFF
--- a/pick.c
+++ b/pick.c
@@ -899,6 +899,7 @@ get_key(const char **key)
 		CAP(END,	"kend"),
 		KEY(END,	"\033>"),
 		KEY(ENTER,	"\n"),
+		CAP(ENTER,	"kent"),
 		CAP(HOME,	"khome"),
 		KEY(HOME,	"\033<"),
 		CAP(LEFT,	"kcub1"),


### PR DESCRIPTION
The kend capability is issued by some keypads while pressing enter in
cursor mode.

Fixes #308