### PR TITLE
Add COPR instructions for Fedora/RHEL/CentOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,18 @@ emerge pick
 ### Fedora/RHEL/CentOS
 
 The RPM builds are not yet in the official repositories, but you can install a
-community-built RPM if you are running Fedora 33 on x86_64:
+community-built RPM.  You can use
+[the COPR repo](https://copr.fedorainfracloud.org/coprs/freedomben/pick/) for all currently
+supported distro versions (see [Active Releases](https://copr.fedorainfracloud.org/coprs/freedomben/pick/)):
+
+```sh
+sudo dnf install -y dnf-plugins-core && \
+sudo dnf copr enable -y freedomben/pick && \
+sudo dnf install -y pick
+```
+
+Alternatively, if you don't like using COPR and want to install the RPM direct, if you are
+running Fedora 33 on x86_64:
 
 ```sh
 wget https://github.com/FreedomBen/pick-rpm/releases/download/v4.0.0/pick-4.0.0-1.fc33.x86_64.rpm


### PR DESCRIPTION
There is a COPR repo available now.  Many users prefer to avoid COPR
repos for various reasons so the old `wget` instructions are still
fully supported.

This is an important step toward getting included in the official Fedora
repos, so we're getting closer!  Can't put a timeline on inclusion yet
but I'm hoping the next major release will include pick directly.

There are _a lot_ of Fedora packaging standards/rules that I have to go
through and conform too, in addition to the standard process, but it's
coming along.