### PR TITLE
configure: Fix build against ncurses with separate tinfo lib

### DIFF
--- a/configure
+++ b/configure
@@ -151,6 +151,9 @@ INSTALL_MAN="$(makevar INSTALL_MAN || echo install)"
 if check_curses -lcurses; then
 	HAVE_CURSES=1
 	LDFLAGS="${LDFLAGS} -lcurses"
+elif check_curses -ltinfow; then
+	HAVE_NCURSESW=1
+	LDFLAGS="${LDFLAGS} -ltinfow"
 elif check_curses -lncursesw; then
 	HAVE_NCURSESW=1
 	LDFLAGS="${LDFLAGS} -lncursesw"


### PR DESCRIPTION
ncurses library can be built with separate tinfo lib. In that case configure check fails with
```
+ cat config.log
+ LDFLAGS=-lcurses
+ check_curses
+ compile
+ cc -Werror -o /dev/null -x c - -lcurses
/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sys-apps/pick-3.0.1/temp/ccbghdyi.o: undefined reference to symbol 'setupterm'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
+ LDFLAGS=-lncursesw
+ check_curses
+ compile
+ cc -Werror -o /dev/null -x c - -lncursesw
/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sys-apps/pick-3.0.1/temp/ccOVkf2c.o: undefined reference to symbol 'setupterm'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libtinfow.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
+ fatal 'curses library not found'
+ '[' 1 -gt 0 ']'
+ echo 'fatal: curses library not found'
fatal: curses library not found
```

Thanks-to: Helmut Jarausch <jarausch@igpm.rwth-aachen.de>
Gentoo-bug: https://bugs.gentoo.org/685712
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>